### PR TITLE
Specified ipython & jupyter-console version #12

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -10,6 +10,8 @@ pkg_name = name
 
 requirements = ['dill',
                 'flask',
+                'ipython<=6.5.0',
+                'jupyter-console==5.2.0',
                 'jupyter',
                 'jupyterhub',
                 'matplotlib',


### PR DESCRIPTION
There is a conflict of versions for dependency 'prompt-toolkit', see https://github.com/HDI-Project/FeatureHub/issues/12 and https://github.com/jupyter/jupyter_console/issues/158. To resolve it, I tried to specify the versions of ipython & jupyter-console.